### PR TITLE
Ignore flutter projects

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,13 +89,14 @@ message "-----> Dart reports version: $CAN_DART_RUN"
 cd $BUILD_DIR
 
 for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cache`; do
+    pub_dir=`dirname $filename`
+
     # Ignore Flutter projects
-    if grep -q "sdk: flutter" "$filename"; then
-      echo "Ignoring Flutter pubspec.yaml"
+    if grep -q "sdk: flutter" "$BUILD_DIR/$pub_dir/$filename"; then
+      echo "*** Ignoring Flutter pubspec.yaml in in $BUILD_DIR/$pub_dir"
       continue
     fi
 
-    pub_dir=`dirname $filename`
     message "*** Found pubspec.yaml in $BUILD_DIR/$pub_dir"
     cd $BUILD_DIR/$pub_dir
 

--- a/bin/compile
+++ b/bin/compile
@@ -89,6 +89,12 @@ message "-----> Dart reports version: $CAN_DART_RUN"
 cd $BUILD_DIR
 
 for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cache`; do
+    # Ignore Flutter projects
+    if grep -q "sdk: flutter" "$filename"; then
+      echo "Ignoring Flutter pubspec.yaml"
+      continue
+    fi
+
     pub_dir=`dirname $filename`
     message "*** Found pubspec.yaml in $BUILD_DIR/$pub_dir"
     cd $BUILD_DIR/$pub_dir

--- a/bin/compile
+++ b/bin/compile
@@ -92,7 +92,7 @@ for filename in `find . -name pubspec.yaml | grep -v dart-sdk | grep -v pub-cach
     pub_dir=`dirname $filename`
 
     # Ignore Flutter projects
-    if grep -q "sdk: flutter" "$BUILD_DIR/$pub_dir/$filename"; then
+    if grep -q "sdk: flutter" "$BUILD_DIR/$filename"; then
       echo "*** Ignoring Flutter pubspec.yaml in in $BUILD_DIR/$pub_dir"
       continue
     fi


### PR DESCRIPTION
I'm using a single repo to handle a flutter project and its aqueduct API, with the following structure:

```
- project-root/
-- flutter-project/
-- aqueduct-project/
-- pure-dart-shared-library/
```

When pushing to heroku, the buildpack looks for all `pubspec.yaml` and tries to run `pub get` on each. However it should ignore pubspec from flutter projects.

The proposed fix is to check if a `pubspec.yaml` contains the following line: `sdk: flutter`, and ignore it if that's the case. My understanding is that is enough, because all Flutter projects must declare:

```
dependencies:
  flutter:
    sdk: flutter
```

What do you think?
Thanks.